### PR TITLE
Add Referer header

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,13 +1,13 @@
-use serde::Serialize;
-use actix_web::{error, HttpResponse, HttpResponseBuilder};
 use actix_web::http::StatusCode;
+use actix_web::{error, HttpResponse, HttpResponseBuilder};
+use serde::Serialize;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ApiError {
     #[error("bili error")]
     BiliError(#[from] bili::Error),
     #[error("transport error")]
-    Reqwest(#[from] reqwest::Error)
+    Reqwest(#[from] reqwest::Error),
 }
 
 #[derive(Debug, Serialize)]
@@ -20,17 +20,15 @@ impl error::ResponseError for ApiError {
         StatusCode::INTERNAL_SERVER_ERROR
     }
 
-
     fn error_response(&self) -> HttpResponse {
-        HttpResponseBuilder::new(self.status_code())
-            .json(ErrorResponse::from(self))
+        HttpResponseBuilder::new(self.status_code()).json(ErrorResponse::from(self))
     }
 }
 
 impl From<&ApiError> for ErrorResponse {
     fn from(e: &ApiError) -> Self {
         Self {
-            err: format!("{}", e)
+            err: format!("{}", e),
         }
     }
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -11,7 +11,11 @@ pub async fn relay(room_id: web::Path<u64>, client: web::Data<reqwest::Client>) 
     let room_id = room_id.into_inner();
     let infos = get_play_url_info(room_id).await?;
     if let Some(play_url) = infos.durl.first() {
-        let resp = client.get(&play_url.url).send().await?;
+        let resp = client
+            .get(&play_url.url)
+            .header("Referer", format!("https://live.bilibili.com/{}", room_id))
+            .send()
+            .await?;
         let headers = resp.headers();
         let mut forged = HttpResponse::Ok();
         for header in headers {

--- a/src/web.rs
+++ b/src/web.rs
@@ -1,5 +1,5 @@
-use actix_web::{get, App, HttpResponse, HttpServer, web};
 use actix_web::middleware::Logger;
+use actix_web::{get, web, App, HttpResponse, HttpServer};
 use bili::live::get_play_url_info;
 
 use crate::error::ApiError;
@@ -7,7 +7,10 @@ use crate::error::ApiError;
 const USER_AGENT: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.93 Safari/537.36";
 
 #[get("/{room_id}")]
-pub async fn relay(room_id: web::Path<u64>, client: web::Data<reqwest::Client>) -> Result<HttpResponse, ApiError> {
+pub async fn relay(
+    room_id: web::Path<u64>,
+    client: web::Data<reqwest::Client>,
+) -> Result<HttpResponse, ApiError> {
     let room_id = room_id.into_inner();
     let infos = get_play_url_info(room_id).await?;
     if let Some(play_url) = infos.durl.first() {
@@ -43,13 +46,13 @@ pub async fn spawn_server() -> anyhow::Result<()> {
                         .content_type("application/json")
                         .body(format!(r#"{{"error":"{}"}}"#, err)),
                 )
-                    .into()
+                .into()
             }))
             .wrap(Logger::default())
             .service(relay)
     })
-        .bind(("::", 8080))?
-        .run()
-        .await?;
+    .bind(("::", 8080))?
+    .run()
+    .await?;
     Ok(())
 }


### PR DESCRIPTION
Without proper headers, an HTTP 459 will be returned.

Required headers:

- Referer: https://live.bilibili.com/<room\> (in this PR)

- User-Agent: \<Browser user agent\> (already provided)